### PR TITLE
Support for Publisher in Function signature

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,15 +12,15 @@
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
 		<version>1.5.9.RELEASE</version>
-		<relativePath/> <!-- lookup parent from repository -->
+		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<java.version>1.8</java.version>
-		<spring-cloud.version>Edgware.SR1</spring-cloud.version>
-		<spring-cloud-function.version>1.0.0.M3</spring-cloud-function.version>
+		<spring-cloud.version>Edgware.SR2</spring-cloud.version>
+		<spring-cloud-function.version>1.0.0.BUILD-SNAPSHOT</spring-cloud-function.version>
 		<spring-cloud-stream-file.version>1.0.0.M1</spring-cloud-stream-file.version>
 		<spring-cloud-deployer.version>1.2.0.RELEASE</spring-cloud-deployer.version>
 		<reactor.version>3.2.0.M1</reactor.version>

--- a/src/test/java/io/projectriff/functions/FluxDoubler.java
+++ b/src/test/java/io/projectriff/functions/FluxDoubler.java
@@ -18,11 +18,13 @@ package io.projectriff.functions;
 
 import java.util.function.Function;
 
+import org.reactivestreams.Publisher;
+
 import reactor.core.publisher.Flux;
 
-public class FluxDoubler implements Function<Flux<Integer>, Flux<Integer>> {
+public class FluxDoubler implements Function<Publisher<Integer>, Publisher<Integer>> {
 	@Override
-	public Flux<Integer> apply(Flux<Integer> integer) {
-		return integer.map(i -> 2*i);
+	public Publisher<Integer> apply(Publisher<Integer> integer) {
+		return Flux.from(integer).map(i -> 2*i);
 	}
 }

--- a/src/test/java/io/projectriff/functions/WordCounter.java
+++ b/src/test/java/io/projectriff/functions/WordCounter.java
@@ -20,17 +20,19 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
 
+import org.reactivestreams.Publisher;
+
 import reactor.core.publisher.Flux;
 
 /**
  * @author Dave Syer
  *
  */
-public class WordCounter implements Function<Flux<String>, Flux<Map<String, Integer>>> {
+public class WordCounter implements Function<Publisher<String>, Publisher<Map<String, Integer>>> {
 
 	@Override
-	public Flux<Map<String, Integer>> apply(Flux<String> words) {
-		return words.window(Duration.ofSeconds(10))
+	public Publisher<Map<String, Integer>> apply(Publisher<String> words) {
+		return Flux.from(words).window(Duration.ofSeconds(10))
 				.flatMap(f -> f.flatMap(word -> Flux.fromArray(word.split("\\W")))
 						.reduce(new HashMap<String, Integer>(), (map, word) -> {
 							map.merge(word, 1, Integer::sum);


### PR DESCRIPTION
User can supply Function<Flux<...>,...> or s/Flux/Publisher/
(or just POJOs).