### PR TITLE
Add mvn clean to README

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -3,7 +3,7 @@
 Testing locally:
 
 ```
-$ ./mvnw install dockerfile:build
+$ ./mvnw clean install dockerfile:build
 $ docker run -ti -p 8080:8080 -v `pwd`/target/test-classes:/classes projectriff/java-function-invoker:0.0.5-snapshot --function.uri='file:classes?handler=io.projectriff.functions.Doubler'
 ```
 


### PR DESCRIPTION
Without this, stale files can be included in the build and cause it to
malfunction.