### PR TITLE
Add some tests for loading functions from jars (fat and not fat)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>1.5.9.RELEASE</version>
+		<version>1.5.10.RELEASE</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 
@@ -20,7 +20,7 @@
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<java.version>1.8</java.version>
 		<spring-cloud.version>Edgware.SR2</spring-cloud.version>
-		<spring-cloud-function.version>1.0.0.M4</spring-cloud-function.version>
+		<spring-cloud-function.version>1.0.0.BUILD-SNAPSHOT</spring-cloud-function.version>
 		<spring-cloud-deployer.version>1.2.0.RELEASE</spring-cloud-deployer.version>
 		<grpc.version>1.8.0</grpc.version>
 		<reactor.version>3.2.0.M1</reactor.version>
@@ -33,6 +33,28 @@
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-function-web</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-web</artifactId>
+			<exclusions>
+				<exclusion>
+					<groupId>org.springframework.boot</groupId>
+					<artifactId>spring-boot-starter-logging</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.hibernate</groupId>
+					<artifactId>hibernate-validator</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>com.fasterxml.jackson.core</groupId>
+					<artifactId>jackson-databind</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-jdk14</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>io.projectriff</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,10 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-loader</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
@@ -168,7 +172,65 @@
 					<tag>${docker.tag}</tag>
 				</configuration>
 			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-invoker-plugin</artifactId>
+				<configuration>
+					<localRepositoryPath>${project.build.directory}/local-repo</localRepositoryPath>
+				</configuration>
+				<executions>
+					<execution>
+						<id>prepare-test</id>
+						<phase>test-compile</phase>
+						<goals>
+							<goal>run</goal>
+						</goals>
+						<configuration>
+							<cloneProjectsTo>${project.build.directory}/it</cloneProjectsTo>
+							<settingsFile>src/it/settings.xml</settingsFile>
+							<addTestClassPath>true</addTestClassPath>
+							<skipInvocation>${skipTests}</skipInvocation>
+							<streamLogs>true</streamLogs>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
+		<pluginManagement>
+			<plugins>
+				<!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
+				<plugin>
+					<groupId>org.eclipse.m2e</groupId>
+					<artifactId>lifecycle-mapping</artifactId>
+					<version>1.0.0</version>
+					<configuration>
+						<lifecycleMappingMetadata>
+							<pluginExecutions>
+								<pluginExecution>
+									<pluginExecutionFilter>
+										<groupId>
+											org.apache.maven.plugins
+										</groupId>
+										<artifactId>
+											maven-invoker-plugin
+										</artifactId>
+										<versionRange>
+											[1.10,)
+										</versionRange>
+										<goals>
+											<goal>run</goal>
+										</goals>
+									</pluginExecutionFilter>
+									<action>
+										<ignore></ignore>
+									</action>
+								</pluginExecution>
+							</pluginExecutions>
+						</lifecycleMappingMetadata>
+					</configuration>
+				</plugin>
+			</plugins>
+		</pluginManagement>
 	</build>
 
 	<profiles>

--- a/src/it/pof/pom.xml
+++ b/src/it/pof/pom.xml
@@ -1,0 +1,124 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>io.spring.sample</groupId>
+	<artifactId>function-sample-pof</artifactId>
+	<version>1.0.0.BUILD-SNAPSHOT</version>
+	<packaging>jar</packaging>
+	<name>function-sample-pof</name>
+	<description>Spring Cloud Function Web Support</description>
+
+	<parent>
+		<groupId>org.springframework.boot</groupId>
+		<artifactId>spring-boot-starter-parent</artifactId>
+		<version>1.5.10.RELEASE</version>
+		<relativePath />
+	</parent>
+
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+		<java.version>1.8</java.version>
+		<reactor.version>3.1.2.RELEASE</reactor.version>
+		<spring-cloud-function.version>1.0.0.BUILD-SNAPSHOT</spring-cloud-function.version>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-starter-function-web</artifactId>
+		</dependency>
+	</dependencies>
+
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>org.springframework.cloud</groupId>
+				<artifactId>spring-cloud-function-dependencies</artifactId>
+				<version>${spring-cloud-function.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-deploy-plugin</artifactId>
+				<configuration>
+					<skip>true</skip>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+				<configuration>
+					<classifier>exec</classifier>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+
+	<repositories>
+		<repository>
+			<id>spring-snapshots</id>
+			<name>Spring Snapshots</name>
+			<url>https://repo.spring.io/libs-snapshot-local</url>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
+			<releases>
+				<enabled>false</enabled>
+			</releases>
+		</repository>
+		<repository>
+			<id>spring-milestones</id>
+			<name>Spring Milestones</name>
+			<url>https://repo.spring.io/libs-milestone-local</url>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
+		</repository>
+		<repository>
+			<id>spring-releases</id>
+			<name>Spring Releases</name>
+			<url>https://repo.spring.io/release</url>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
+		</repository>
+	</repositories>
+	<pluginRepositories>
+		<pluginRepository>
+			<id>spring-snapshots</id>
+			<name>Spring Snapshots</name>
+			<url>https://repo.spring.io/libs-snapshot-local</url>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
+			<releases>
+				<enabled>false</enabled>
+			</releases>
+		</pluginRepository>
+		<pluginRepository>
+			<id>spring-milestones</id>
+			<name>Spring Milestones</name>
+			<url>https://repo.spring.io/libs-milestone-local</url>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
+		</pluginRepository>
+		<pluginRepository>
+			<id>spring-releases</id>
+			<name>Spring Releases</name>
+			<url>https://repo.spring.io/libs-release-local</url>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
+		</pluginRepository>
+	</pluginRepositories>
+
+</project>

--- a/src/it/pof/src/main/java/functions/Application.java
+++ b/src/it/pof/src/main/java/functions/Application.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package functions;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class Application {
+
+	public static void main(String[] args) {
+		SpringApplication.run(Application.class, args);
+	}
+}

--- a/src/it/pof/src/main/java/functions/Greeter.java
+++ b/src/it/pof/src/main/java/functions/Greeter.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package functions;
+
+import java.util.function.Function;
+
+public class Greeter implements Function<String, String> {
+
+	public String apply(String name) {
+		return "Hello " + name;
+	}
+}

--- a/src/it/settings.xml
+++ b/src/it/settings.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<settings>
+	<profiles>
+		<profile>
+			<id>it-repo</id>
+			<activation>
+				<activeByDefault>true</activeByDefault>
+			</activation>
+			<repositories>
+				<repository>
+					<id>local.central</id>
+					<url>@localRepositoryUrl@</url>
+					<releases>
+						<enabled>true</enabled>
+					</releases>
+					<snapshots>
+						<enabled>true</enabled>
+					</snapshots>
+				</repository>
+			</repositories>
+			<pluginRepositories>
+				<pluginRepository>
+					<id>local.central</id>
+					<url>@localRepositoryUrl@</url>
+					<releases>
+						<enabled>true</enabled>
+					</releases>
+					<snapshots>
+						<enabled>true</enabled>
+					</snapshots>
+				</pluginRepository>
+			</pluginRepositories>
+		</profile>
+	</profiles>
+</settings>

--- a/src/main/java/io/projectriff/invoker/ContextRunner.java
+++ b/src/main/java/io/projectriff/invoker/ContextRunner.java
@@ -54,9 +54,14 @@ public class ContextRunner {
 							StandardEnvironment.SYSTEM_ENVIRONMENT_PROPERTY_SOURCE_NAME,
 							new MapPropertySource("appDeployer", properties));
 					running = true;
-					context = new SpringApplicationBuilder(source)
-							.listeners(new BeanCountingApplicationListener())
-							.environment(environment).registerShutdownHook(false)
+					SpringApplicationBuilder builder = new SpringApplicationBuilder(
+							source);
+					if (ClassUtils.isPresent(
+							"io.projectriff.invoker.BeanCountingApplicationListener",
+							null)) {
+						builder.listeners(new BeanCountingApplicationListener());
+					}
+					context = builder.environment(environment).registerShutdownHook(false)
 							.run(args);
 				}
 				catch (Throwable ex) {

--- a/src/main/java/io/projectriff/invoker/FunctionProperties.java
+++ b/src/main/java/io/projectriff/invoker/FunctionProperties.java
@@ -21,7 +21,6 @@ import java.util.regex.Pattern;
 import java.util.stream.IntStream;
 
 import javax.annotation.PostConstruct;
-import javax.validation.constraints.NotNull;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -43,7 +42,6 @@ public class FunctionProperties {
 
 	private static Log logger = LogFactory.getLog(FunctionProperties.class);
 
-	@NotNull
 	private String uri;
 	private String[] jarLocation;
 	private String[] className;
@@ -74,12 +72,12 @@ public class FunctionProperties {
 			logger.info("initializing with uri: " + uri);
 			Matcher m = uriPattern.matcher(uri);
 			Assert.isTrue(m.matches(),
-				"expected format: <jarLocation>?handler=<className>[&main=<className>]");
+					"expected format: <jarLocation>?handler=<className>[&main=<className>]");
 
 			String jarLocation = m.group(1);
 			String className = m.group(2);
 			String rest = m.group(3);
-			if (rest!=null && rest.startsWith("main=")) {
+			if (rest != null && rest.startsWith("main=")) {
 				this.mainClassName = rest.substring("main=".length());
 			}
 

--- a/src/main/java/io/projectriff/invoker/GrpcConfiguration.java
+++ b/src/main/java/io/projectriff/invoker/GrpcConfiguration.java
@@ -30,8 +30,8 @@ import org.apache.commons.logging.LogFactory;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.cloud.function.context.FunctionCatalog;
 import org.springframework.cloud.function.context.catalog.FunctionInspector;
-import org.springframework.cloud.function.core.FunctionCatalog;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.event.ContextRefreshedEvent;
 import org.springframework.context.event.EventListener;
@@ -73,13 +73,13 @@ public class GrpcConfiguration {
 	@EventListener(ContextRefreshedEvent.class)
 	public void start() throws IOException {
 		try {
-			Function<Flux<?>, Flux<?>> function = catalog
-					.lookupFunction(functions.getFunctionName());
+			Function<Flux<?>, Flux<?>> function = catalog.lookup(Function.class,
+					functions.getFunctionName());
 			this.server = ServerBuilder.forPort(this.port)
 					.addService(new JavaFunctionInvokerServer(function, this.mapper,
-							inspector.getInputType(function),
-							inspector.getOutputType(function),
-							inspector.isMessage(function)))
+							inspector.getRegistration(function).getType().getInputType(),
+							inspector.getRegistration(function).getType().getOutputType(),
+							inspector.getRegistration(function).getType().isMessage()))
 					.build();
 			this.server.start();
 		}

--- a/src/test/java/io/projectriff/invoker/FatJarTests.java
+++ b/src/test/java/io/projectriff/invoker/FatJarTests.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2016-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.projectriff.invoker;
+
+import java.io.File;
+import java.net.URI;
+
+import org.junit.After;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.RequestEntity;
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.SocketUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Dave Syer
+ *
+ */
+public class FatJarTests {
+
+	private TestRestTemplate rest;
+	private int port = SocketUtils.findAvailableTcpPort();
+
+	private File sampleJar;
+
+	private JavaFunctionInvokerApplication runner;
+
+	@Before
+	public void init() {
+		runner = new JavaFunctionInvokerApplication();
+		rest = new TestRestTemplate();
+	}
+
+	@After
+	public void close() throws Exception {
+		if (runner != null) {
+			runner.close();
+		}
+	}
+
+	@Before
+	public void check() {
+		sampleJar = new File(
+				"target/it/pof/target/function-sample-pof-1.0.0.BUILD-SNAPSHOT-exec.jar");
+		Assume.assumeTrue("Sample jar does not exist: " + sampleJar, sampleJar.exists());
+	}
+
+	@Test
+	public void fatJar() throws Exception {
+		runner.run("--server.port=" + port, "--grpc.port=0",
+				"--function.uri=" + sampleJar.toURI() + "?handler=functions.Greeter");
+		ResponseEntity<String> result = rest
+				.exchange(
+						RequestEntity.post(new URI("http://localhost:" + port + "/"))
+								.contentType(MediaType.TEXT_PLAIN).body("World"),
+						String.class);
+		assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+		assertThat(result.getBody()).isEqualTo("Hello World");
+	}
+
+	@Test
+	public void libJar() throws Exception {
+		String uri = sampleJar.toURI().toString();
+		uri = uri.replaceAll("-exec", "");
+		runner.run("--server.port=" + port, "--grpc.port=0",
+				"--function.uri=" + uri + "?handler=functions.Greeter");
+		ResponseEntity<String> result = rest
+				.exchange(
+						RequestEntity.post(new URI("http://localhost:" + port + "/"))
+								.contentType(MediaType.TEXT_PLAIN).body("World"),
+						String.class);
+		assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+		assertThat(result.getBody()).isEqualTo("Hello World");
+	}
+
+}

--- a/src/test/java/io/projectriff/invoker/FunctionConfigurationTests.java
+++ b/src/test/java/io/projectriff/invoker/FunctionConfigurationTests.java
@@ -27,8 +27,8 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.rule.OutputCapture;
+import org.springframework.cloud.function.context.FunctionCatalog;
 import org.springframework.cloud.function.context.catalog.InMemoryFunctionCatalog;
-import org.springframework.cloud.function.core.FunctionCatalog;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
@@ -52,7 +52,7 @@ public abstract class FunctionConfigurationTests {
 
 		@Test
 		public void testDouble() {
-			Function<Integer, Integer> function = catalog.lookupFunction("function0");
+			Function<Integer, Integer> function = catalog.lookup(Function.class, "function0");
 			assertThat(function.apply(2), is(4));
 		}
 	}
@@ -67,13 +67,13 @@ public abstract class FunctionConfigurationTests {
 
 		@Test
 		public void testSupplier() {
-			Supplier<Integer> function = catalog.lookupSupplier("function0");
+			Supplier<Integer> function = catalog.lookup(Supplier.class, "function0");
 			assertThat(function.get(), is(1));
 		}
 
 		@Test
 		public void testFunction() {
-			Function<Integer, String> function = catalog.lookupFunction("function1");
+			Function<Integer, String> function = catalog.lookup(Function.class, "function1");
 			assertThat(function.apply(1), is("un"));
 		}
 
@@ -89,13 +89,13 @@ public abstract class FunctionConfigurationTests {
 
 		@Test
 		public void testFunction() {
-			Function<Integer, Integer> function = catalog.lookupFunction("function0");
+			Function<Integer, Integer> function = catalog.lookup(Function.class, "function0");
 			assertThat(function.apply(2), is(4));
 		}
 
 		@Test
 		public void testThen() {
-			Function<Integer, String> function = catalog.lookupFunction("function1");
+			Function<Integer, String> function = catalog.lookup(Function.class, "function1");
 			assertThat(function.apply(4), is("quatre"));
 		}
 	}
@@ -113,7 +113,7 @@ public abstract class FunctionConfigurationTests {
 
 		@Test
 		public void testConsumer() {
-			Consumer<String> function = catalog.lookupConsumer("function1");
+			Consumer<String> function = catalog.lookup(Consumer.class, "function1");
 			function.accept("2");
 			capture.expect(containsString("Seen 2"));
 		}

--- a/src/test/java/io/projectriff/invoker/IsolatedTests.java
+++ b/src/test/java/io/projectriff/invoker/IsolatedTests.java
@@ -65,14 +65,16 @@ public class IsolatedTests {
 	public void fluxFunctionNotIsolated() throws Exception {
 		expected.expect(BeanCreationException.class);
 		SpringApplication.run(JavaFunctionInvokerApplication.class,
-				"--server.port=" + port, "--function.uri=file:target/test-classes"
+				"--server.port=" + port, "--grpc.port=0",
+				"--function.uri=file:target/test-classes"
 						+ "?handler=io.projectriff.functions.FluxDoubler");
 	}
 
 	@Test
 	public void fluxFunction() throws Exception {
-		runner.run("--server.port=" + port, "--function.uri=file:target/test-classes"
-				+ "?handler=io.projectriff.functions.FluxDoubler");
+		runner.run("--server.port=" + port, "--grpc.port=0",
+				"--function.uri=file:target/test-classes"
+						+ "?handler=io.projectriff.functions.FluxDoubler");
 		ResponseEntity<String> result = rest
 				.exchange(
 						RequestEntity.post(new URI("http://localhost:" + port + "/"))
@@ -88,7 +90,7 @@ public class IsolatedTests {
 
 	@Test
 	public void messageFunction() throws Exception {
-		runner.run("--server.port=" + port,
+		runner.run("--server.port=" + port, "--grpc.port=0",
 				"--function.uri=file:target/test-classes,file:target/test-functions"
 						+ "?handler=io.projectriff.functions.MessageGreeter");
 		ResponseEntity<String> result = rest
@@ -102,7 +104,7 @@ public class IsolatedTests {
 
 	@Test
 	public void fluxMessageFunction() throws Exception {
-		runner.run("--server.port=" + port,
+		runner.run("--server.port=" + port, "--grpc.port=0",
 				"--function.uri=file:target/test-classes,file:target/test-functions"
 						+ "?handler=io.projectriff.functions.FluxMessageGreeter");
 		ResponseEntity<String> result = rest.exchange(RequestEntity
@@ -115,8 +117,9 @@ public class IsolatedTests {
 
 	@Test
 	public void simpleFunction() throws Exception {
-		runner.run("--server.port=" + port, "--function.uri=file:target/test-classes"
-				+ "?handler=io.projectriff.functions.Doubler");
+		runner.run("--server.port=" + port, "--grpc.port=0",
+				"--function.uri=file:target/test-classes"
+						+ "?handler=io.projectriff.functions.Doubler");
 		ResponseEntity<String> result = rest
 				.exchange(
 						RequestEntity.post(new URI("http://localhost:" + port + "/"))
@@ -128,8 +131,9 @@ public class IsolatedTests {
 
 	@Test
 	public void appClassPath() throws Exception {
-		runner.run("--server.port=" + port, "--function.uri=app:classpath?"
-				+ "handler=io.projectriff.functions.SpringDoubler");
+		runner.run("--server.port=" + port, "--grpc.port=0",
+				"--function.uri=app:classpath?"
+						+ "handler=io.projectriff.functions.SpringDoubler");
 		ResponseEntity<String> result = rest
 				.exchange(
 						RequestEntity.post(new URI("http://localhost:" + port + "/"))
@@ -141,8 +145,9 @@ public class IsolatedTests {
 
 	@Test
 	public void mainClassBeanName() throws Exception {
-		runner.run("--server.port=" + port, "--function.uri=app:classpath?"
-				+ "handler=myDoubler&" + "main=io.projectriff.functions.FunctionApp");
+		runner.run("--server.port=" + port, "--grpc.port=0",
+				"--function.uri=app:classpath?" + "handler=myDoubler&"
+						+ "main=io.projectriff.functions.FunctionApp");
 		ResponseEntity<String> result = rest
 				.exchange(
 						RequestEntity.post(new URI("http://localhost:" + port + "/"))
@@ -154,7 +159,7 @@ public class IsolatedTests {
 
 	@Test
 	public void mainClassBeanType() throws Exception {
-		runner.run("--server.port=" + port,
+		runner.run("--server.port=" + port, "--grpc.port=0",
 				"--function.uri=app:classpath?"
 						+ "handler=io.projectriff.functions.Doubler&"
 						+ "main=io.projectriff.functions.FunctionApp");


### PR DESCRIPTION
Uses the spring-boot-loader to extract a classpath from a fat jar if it
looks like it has BOOT-INF packaging. Otherwise assumes the jar is flat
(e.g. shaded). The test is a good start, but we should add more because
there is a missing feature - @Beans (rather than
@Components or scanned functions) will not have enough type information in
their runtime class metadata. Probably need to go into the
FunctionInspector in the user context to extract the type information.

See #31. Apply on top of #30.