### PR TITLE
Allow multi-file URI to contain a fat jar

### DIFF
--- a/src/main/java/io/projectriff/invoker/FunctionConfiguration.java
+++ b/src/main/java/io/projectriff/invoker/FunctionConfiguration.java
@@ -22,7 +22,9 @@ import java.io.UncheckedIOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -133,16 +135,23 @@ public class FunctionConfiguration {
 	}
 
 	private URL[] expand(URL[] urls) {
-		if (urls.length != 1 || !"file".equals(urls[0].getProtocol())) {
-			return urls;
+		List<URL> result = new ArrayList<>();
+		for (URL url : urls) {
+			result.addAll(expand(url));
 		}
-		URL url = urls[0];
+		return result.toArray(new URL[0]);
+	}
+	
+	private List<URL> expand(URL url) {
+		if (!"file".equals(url.getProtocol())) {
+			return Collections.singletonList(url);
+		}
 		if (!url.toString().endsWith(".jar")) {
-			return urls;
+			return Collections.singletonList(url);
 		}
 		try {
 			JarFileArchive archive = new JarFileArchive(new File(url.toURI()));
-			return new ComputeLauncher(archive).getClassLoaderUrls();
+			return Arrays.asList(new ComputeLauncher(archive).getClassLoaderUrls());
 		}
 		catch (Exception e) {
 			throw new IllegalStateException("Cannot create class loader for " + url, e);

--- a/src/main/java/io/projectriff/invoker/GrpcConfiguration.java
+++ b/src/main/java/io/projectriff/invoker/GrpcConfiguration.java
@@ -71,7 +71,7 @@ public class GrpcConfiguration {
 
 	/** Start serving requests. */
 	@EventListener(ContextRefreshedEvent.class)
-	public void start() throws IOException {
+	public void start() {
 		try {
 			Function<Flux<?>, Flux<?>> function = catalog.lookup(Function.class,
 					functions.getFunctionName());
@@ -84,7 +84,7 @@ public class GrpcConfiguration {
 			this.server.start();
 		}
 		catch (IOException e) {
-			throw new IOException(String
+			throw new IllegalStateException(String
 					.format("gRPC server failed to start listening on port %d", port), e);
 		}
 		logger.info("Server started, listening on " + port);

--- a/src/test/java/io/projectriff/invoker/ComposedJavaFunctionInvokerApplicationTests.java
+++ b/src/test/java/io/projectriff/invoker/ComposedJavaFunctionInvokerApplicationTests.java
@@ -42,8 +42,8 @@ import org.springframework.test.context.junit4.SpringRunner;
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 @DirtiesContext
-@TestPropertySource(properties = "function.uri=file:target/test-classes"
-		+ "?handler=io.projectriff.functions.Doubler,io.projectriff.functions.Frenchizer")
+@TestPropertySource(properties = {"grpc.port=0", "function.uri=file:target/test-classes"
+		+ "?handler=io.projectriff.functions.Doubler,io.projectriff.functions.Frenchizer"})
 public class ComposedJavaFunctionInvokerApplicationTests {
 
 	@Autowired

--- a/src/test/java/io/projectriff/invoker/FatJarPojoTests.java
+++ b/src/test/java/io/projectriff/invoker/FatJarPojoTests.java
@@ -44,6 +44,7 @@ public class FatJarPojoTests {
 	private File sampleJar;
 
 	private JavaFunctionInvokerApplication runner;
+	private File sampleDir;
 
 	@Before
 	public void init() {
@@ -60,6 +61,7 @@ public class FatJarPojoTests {
 
 	@Before
 	public void check() {
+		sampleDir = new File("target/it/pojo/target/classes");
 		sampleJar = new File(
 				"target/it/pojo/target/function-sample-pojo-1.0.0.BUILD-SNAPSHOT.jar");
 		Assume.assumeTrue("Sample jar does not exist: " + sampleJar, sampleJar.exists());
@@ -78,4 +80,16 @@ public class FatJarPojoTests {
 		assertThat(result.getBody()).isEqualTo("[{\"value\":\"FOO\"}]");
 	}
 
+	@Test
+	public void fatJarAndDirectory() throws Exception {
+		runner.run("--server.port=" + port, "--grpc.port=0",
+				"--function.uri=" + sampleDir.toURI() + "," + sampleJar.toURI()
+						+ "?handler=uppercase&main=com.example.SampleApplication");
+		ResponseEntity<String> result = rest.exchange(RequestEntity
+				.post(new URI("http://localhost:" + port + "/"))
+				.contentType(MediaType.APPLICATION_JSON).body("{\"value\":\"foo\"}"),
+				String.class);
+		assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+		assertThat(result.getBody()).isEqualTo("[{\"value\":\"FOO\"}]");
+	}
 }

--- a/src/test/java/io/projectriff/invoker/JavaFunctionInvokerApplicationTests.java
+++ b/src/test/java/io/projectriff/invoker/JavaFunctionInvokerApplicationTests.java
@@ -41,8 +41,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 @DirtiesContext
-@TestPropertySource(properties = "function.uri=file:target/test-classes"
-		+ "?handler=io.projectriff.functions.Doubler")
+@TestPropertySource(properties = { "grpc.port=0", "function.uri=file:target/test-classes"
+		+ "?handler=io.projectriff.functions.Doubler" })
 public class JavaFunctionInvokerApplicationTests {
 
 	@Autowired


### PR DESCRIPTION
There was an unecessary test that restricted fat jar classpath
building to a single valued function.uri. This change lifts the
restriction.

Also fixes tests that didn't randomize the grpc port.