### PR TITLE
Support functions using Spring Boot 2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
 		<dependency>
 			<groupId>io.projectriff</groupId>
 			<artifactId>riff-function-proto</artifactId>
-			<version>0.0.4</version>
+			<version>0.0.5-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>io.grpc</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -126,6 +126,9 @@
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
+				<configuration>
+					<classifier>exec</classifier>
+				</configuration>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
@@ -143,6 +146,7 @@
 									<groupId>${project.groupId}</groupId>
 									<artifactId>${project.artifactId}</artifactId>
 									<version>${project.version}</version>
+									<classifier>exec</classifier>
 								</artifactItem>
 							</artifactItems>
 						</configuration>
@@ -198,7 +202,8 @@
 		</plugins>
 		<pluginManagement>
 			<plugins>
-				<!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
+				<!--This plugin's configuration is used to store Eclipse m2e settings 
+					only. It has no influence on the Maven build itself. -->
 				<plugin>
 					<groupId>org.eclipse.m2e</groupId>
 					<artifactId>lifecycle-mapping</artifactId>

--- a/src/it/next/pom.xml
+++ b/src/it/next/pom.xml
@@ -1,0 +1,131 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>io.spring.sample</groupId>
+	<artifactId>function-sample-next</artifactId>
+	<version>1.0.0.BUILD-SNAPSHOT</version>
+	<packaging>jar</packaging>
+	<name>function-sample-pojo</name>
+	<description>Spring Cloud Function Web Support</description>
+
+	<parent>
+		<groupId>org.springframework.boot</groupId>
+		<artifactId>spring-boot-starter-parent</artifactId>
+		<version>2.0.0.RELEASE</version>
+		<relativePath/>
+	</parent>
+
+	<properties>
+		<java.version>1.8</java.version>
+		<spring-cloud-function.version>1.0.0.BUILD-SNAPSHOT</spring-cloud-function.version>
+		<wrapper.version>1.0.9.RELEASE</wrapper.version>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-starter-function-web</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-configuration-processor</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>org.springframework.cloud</groupId>
+				<artifactId>spring-cloud-function-dependencies</artifactId>
+				<version>${spring-cloud-function.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-deploy-plugin</artifactId>
+				<configuration>
+					<skip>true</skip>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin>
+		</plugins>
+	</build>
+
+	<repositories>
+		<repository>
+			<id>spring-snapshots</id>
+			<name>Spring Snapshots</name>
+			<url>https://repo.spring.io/libs-snapshot-local</url>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
+			<releases>
+				<enabled>false</enabled>
+			</releases>
+		</repository>
+		<repository>
+			<id>spring-milestones</id>
+			<name>Spring Milestones</name>
+			<url>https://repo.spring.io/libs-milestone-local</url>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
+		</repository>
+		<repository>
+			<id>spring-releases</id>
+			<name>Spring Releases</name>
+			<url>https://repo.spring.io/release</url>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
+		</repository>
+	</repositories>
+	<pluginRepositories>
+		<pluginRepository>
+			<id>spring-snapshots</id>
+			<name>Spring Snapshots</name>
+			<url>https://repo.spring.io/libs-snapshot-local</url>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
+			<releases>
+				<enabled>false</enabled>
+			</releases>
+		</pluginRepository>
+		<pluginRepository>
+			<id>spring-milestones</id>
+			<name>Spring Milestones</name>
+			<url>https://repo.spring.io/libs-milestone-local</url>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
+		</pluginRepository>
+		<pluginRepository>
+			<id>spring-releases</id>
+			<name>Spring Releases</name>
+			<url>https://repo.spring.io/libs-release-local</url>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
+		</pluginRepository>
+	</pluginRepositories>
+
+</project>

--- a/src/it/next/src/main/java/com/example/LowercaseConfiguration.java
+++ b/src/it/next/src/main/java/com/example/LowercaseConfiguration.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2016-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example;
+
+import java.util.function.Function;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import reactor.core.publisher.Flux;
+
+/**
+ * @author Dave Syer
+ *
+ */
+@Configuration
+public class LowercaseConfiguration {
+
+	@Bean
+	public Function<Flux<Foo>, Flux<Bar>> lowercase() {
+		return flux -> flux.log().map(value -> new Bar(value.lowercase()));
+	}
+
+}

--- a/src/it/next/src/main/java/com/example/SampleApplication.java
+++ b/src/it/next/src/main/java/com/example/SampleApplication.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package com.example;
+
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+
+import reactor.core.publisher.Flux;
+
+@SpringBootApplication
+public class SampleApplication {
+
+	@Bean
+	public Function<Flux<Foo>, Flux<Bar>> uppercase() {
+		return flux -> flux.log().map(value -> new Bar(value.uppercase()));
+	}
+
+	@Bean
+	public Supplier<Flux<Bar>> words() {
+		return () -> Flux.fromArray(new Bar[] { new Bar("foo"), new Bar("bar") }).log();
+	}
+
+	public static void main(String[] args) throws Exception {
+		SpringApplication.run(SampleApplication.class, args);
+	}
+
+}
+
+class Foo {
+
+	private String value;
+
+	Foo() {
+	}
+
+	public String lowercase() {
+		return value.toLowerCase();
+	}
+
+	public Foo(String value) {
+		this.value = value;
+	}
+
+	public String uppercase() {
+		return value.toUpperCase();
+	}
+
+	public String getValue() {
+		return value;
+	}
+
+	public void setValue(String value) {
+		this.value = value;
+	}
+}
+
+class Bar {
+
+	private String value;
+
+	Bar() {
+	}
+
+	public Bar(String value) {
+		this.value = value;
+	}
+
+	public String getValue() {
+		return value;
+	}
+
+	public void setValue(String value) {
+		this.value = value;
+	}
+
+}

--- a/src/it/next/src/main/resources/application.properties
+++ b/src/it/next/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+management.security.enabled: false

--- a/src/it/next/src/test/java/com/example/SampleApplicationTests.java
+++ b/src/it/next/src/test/java/com/example/SampleApplicationTests.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2016-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.example;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Dave Syer
+ *
+ */
+@RunWith(SpringRunner.class)
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+public class SampleApplicationTests {
+
+	@LocalServerPort
+	private int port;
+
+	@Test
+	public void words() {
+		assertThat(new TestRestTemplate()
+				.getForObject("http://localhost:" + port + "/words", String.class))
+						.isEqualTo("[{\"value\":\"foo\"},{\"value\":\"bar\"}]");
+	}
+
+	@Test
+	public void uppercase() {
+		// TODO: make this work with a JSON stream as well (like in WebFlux)
+		assertThat(new TestRestTemplate().postForObject(
+				"http://localhost:" + port + "/uppercase", "[{\"value\":\"foo\"}]",
+				String.class)).isEqualTo("[{\"value\":\"FOO\"}]");
+	}
+
+	@Test
+	public void lowercase() {
+		assertThat(new TestRestTemplate().postForObject(
+				"http://localhost:" + port + "/lowercase", "[{\"value\":\"Foo\"}]",
+				String.class)).isEqualTo("[{\"value\":\"foo\"}]");
+	}
+
+}

--- a/src/main/java/io/projectriff/invoker/ExceptionConverter.java
+++ b/src/main/java/io/projectriff/invoker/ExceptionConverter.java
@@ -1,46 +1,59 @@
 package io.projectriff.invoker;
 
-import io.grpc.Status;
-
 import java.io.FileNotFoundException;
 import java.security.AccessControlException;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.TimeoutException;
+
+import io.grpc.Status;
 
 /**
  * Utility class for converting exceptions to gRPC status values.
  */
 final class ExceptionConverter {
 	static Status createStatus(Throwable t) {
-		return Status.fromCode(determineCode(t))
-				.withDescription(t.getMessage())
+		return Status.fromCode(determineCode(t)).withDescription(t.getMessage())
 				.withCause(t);
 	}
 
 	private static Status.Code determineCode(Throwable t) {
-		if (t instanceof CancellationException) return Status.Code.CANCELLED;
+		if (t instanceof CancellationException)
+			return Status.Code.CANCELLED;
 
-		if (t instanceof IllegalArgumentException) return Status.Code.INVALID_ARGUMENT;
+		if (t instanceof IllegalArgumentException)
+			return Status.Code.INVALID_ARGUMENT;
 
-		if (t instanceof TimeoutException) return Status.Code.DEADLINE_EXCEEDED;
+		if (t instanceof TimeoutException)
+			return Status.Code.DEADLINE_EXCEEDED;
 
-		if (t instanceof ClassNotFoundException) return Status.Code.NOT_FOUND;
-		if (t instanceof FileNotFoundException) return Status.Code.NOT_FOUND;
-		if (t instanceof NoSuchFieldException) return Status.Code.NOT_FOUND;
-		if (t instanceof NoSuchMethodException) return Status.Code.NOT_FOUND;
+		if (t instanceof ClassNotFoundException)
+			return Status.Code.NOT_FOUND;
+		if (t instanceof FileNotFoundException)
+			return Status.Code.NOT_FOUND;
+		if (t instanceof NoSuchFieldException)
+			return Status.Code.NOT_FOUND;
+		if (t instanceof NoSuchMethodException)
+			return Status.Code.NOT_FOUND;
 
-		if (t instanceof AccessControlException) return Status.Code.PERMISSION_DENIED;
+		if (t instanceof AccessControlException)
+			return Status.Code.PERMISSION_DENIED;
 
-		if (t instanceof IllegalStateException) return Status.Code.FAILED_PRECONDITION;
+		if (t instanceof IllegalStateException)
+			return Status.Code.FAILED_PRECONDITION;
 
-		if (t instanceof InterruptedException) return Status.Code.ABORTED;
+		if (t instanceof InterruptedException)
+			return Status.Code.ABORTED;
 
-		if (t instanceof ArrayIndexOutOfBoundsException) return Status.Code.OUT_OF_RANGE;
-		if (t instanceof StringIndexOutOfBoundsException) return Status.Code.OUT_OF_RANGE;
+		if (t instanceof ArrayIndexOutOfBoundsException)
+			return Status.Code.OUT_OF_RANGE;
+		if (t instanceof StringIndexOutOfBoundsException)
+			return Status.Code.OUT_OF_RANGE;
 
-		if (t instanceof UnsupportedOperationException) return Status.Code.UNIMPLEMENTED;
+		if (t instanceof UnsupportedOperationException)
+			return Status.Code.UNIMPLEMENTED;
 
-		if (t instanceof RuntimeException) return Status.Code.INTERNAL;
+		if (t instanceof RuntimeException)
+			return Status.Code.INTERNAL;
 
 		return Status.Code.UNKNOWN;
 	}

--- a/src/main/java/io/projectriff/invoker/FunctionConfiguration.java
+++ b/src/main/java/io/projectriff/invoker/FunctionConfiguration.java
@@ -125,7 +125,7 @@ public class FunctionConfiguration {
 
 		try {
 			this.creator = new BeanCreator(expand(urls));
-			this.creator.run(properties.getMainClassName());
+			this.creator.run(properties.getMain());
 			Arrays.stream(properties.getClassName()).map(this.creator::create)
 					.sequential().forEach(this.creator::register);
 		}

--- a/src/main/java/io/projectriff/invoker/FunctionProperties.java
+++ b/src/main/java/io/projectriff/invoker/FunctionProperties.java
@@ -46,9 +46,9 @@ public class FunctionProperties {
 	private String[] jarLocation;
 	private String[] className;
 
-	private String functionName;
+	private String name;
 
-	private String mainClassName;
+	private String main;
 
 	public String getUri() {
 		return uri;
@@ -78,24 +78,28 @@ public class FunctionProperties {
 			String className = m.group(2);
 			String rest = m.group(3);
 			if (rest != null && rest.startsWith("main=")) {
-				this.mainClassName = rest.substring("main=".length());
+				this.main = rest.substring("main=".length());
 			}
 
 			this.jarLocation = StringUtils.commaDelimitedListToStringArray(jarLocation);
 			this.className = StringUtils.commaDelimitedListToStringArray(className);
 		}
-		if (this.className != null) {
-			this.functionName = StringUtils
+		if (this.className != null && this.name == null) {
+			this.name = StringUtils
 					.arrayToCommaDelimitedString(IntStream.range(0, this.className.length)
 							.sequential().mapToObj(i -> "function" + i).toArray());
 		}
 	}
 
-	public String getFunctionName() {
-		return this.functionName;
+	public String getName() {
+		return this.name;
 	}
 
-	public String getMainClassName() {
-		return this.mainClassName;
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public String getMain() {
+		return this.main;
 	}
 }

--- a/src/main/java/io/projectriff/invoker/GrpcConfiguration.java
+++ b/src/main/java/io/projectriff/invoker/GrpcConfiguration.java
@@ -76,17 +76,17 @@ public class GrpcConfiguration {
 	public void start() {
 		try {
 			Function<Flux<?>, Flux<?>> function = catalog.lookup(Function.class,
-					functions.getFunctionName());
+					functions.getName());
 			Supplier<Flux<?>> supplier = null;
 			Consumer<Flux<?>> consumer = null;
 			if (function == null) {
-				supplier = catalog.lookup(Supplier.class, functions.getFunctionName());
+				supplier = catalog.lookup(Supplier.class, functions.getName());
 				if (supplier == null) {
 					consumer = catalog.lookup(Consumer.class,
-							functions.getFunctionName());
+							functions.getName());
 					if (consumer == null) {
 						throw new IllegalStateException(
-								"No such function: " + functions.getFunctionName());
+								"No such function: " + functions.getName());
 					}
 				}
 			}

--- a/src/main/java/io/projectriff/invoker/GrpcConfiguration.java
+++ b/src/main/java/io/projectriff/invoker/GrpcConfiguration.java
@@ -16,7 +16,9 @@
 package io.projectriff.invoker;
 
 import java.io.IOException;
+import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 import javax.annotation.PreDestroy;
 
@@ -75,16 +77,37 @@ public class GrpcConfiguration {
 		try {
 			Function<Flux<?>, Flux<?>> function = catalog.lookup(Function.class,
 					functions.getFunctionName());
+			Supplier<Flux<?>> supplier = null;
+			Consumer<Flux<?>> consumer = null;
 			if (function == null) {
-				throw new IllegalStateException(
-						"No such function: " + functions.getFunctionName());
+				supplier = catalog.lookup(Supplier.class, functions.getFunctionName());
+				if (supplier == null) {
+					consumer = catalog.lookup(Consumer.class,
+							functions.getFunctionName());
+					if (consumer == null) {
+						throw new IllegalStateException(
+								"No such function: " + functions.getFunctionName());
+					}
+				}
 			}
-			this.server = ServerBuilder.forPort(this.port)
-					.addService(new JavaFunctionInvokerServer(function, this.mapper,
-							inspector.getInputType(function),
-							inspector.getOutputType(function),
-							inspector.isMessage(function)))
-					.build();
+			ServerBuilder<?> builder = ServerBuilder.forPort(this.port);
+			if (function != null) {
+				builder = builder.addService(new JavaFunctionInvokerServer(function,
+						this.mapper, inspector.getInputType(function),
+						inspector.getOutputType(function),
+						inspector.isMessage(function)));
+			}
+			else if (supplier != null) {
+				builder = builder.addService(new JavaSupplierInvokerServer(supplier,
+						this.mapper, inspector.getOutputType(supplier),
+						inspector.isMessage(supplier)));
+			}
+			else {
+				builder = builder.addService(new JavaConsumerInvokerServer(consumer,
+						this.mapper, inspector.getInputType(consumer),
+						inspector.isMessage(consumer)));
+			}
+			this.server = builder.build();
 			this.server.start();
 		}
 		catch (IOException e) {

--- a/src/main/java/io/projectriff/invoker/JavaConsumerInvokerServer.java
+++ b/src/main/java/io/projectriff/invoker/JavaConsumerInvokerServer.java
@@ -25,8 +25,8 @@ import com.google.gson.Gson;
 
 import org.springframework.messaging.Message;
 
-import reactor.core.publisher.EmitterProcessor;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.UnicastProcessor;
 
 /**
  * @author Eric Bottard
@@ -50,7 +50,7 @@ public class JavaConsumerInvokerServer
 	public StreamObserver<io.projectriff.grpc.function.FunctionProtos.Message> call(
 			StreamObserver<io.projectriff.grpc.function.FunctionProtos.Message> responseObserver) {
 
-		EmitterProcessor<Message<?>> emitter = EmitterProcessor.<Message<?>>create();
+		UnicastProcessor<Message<?>> emitter = UnicastProcessor.<Message<?>>create();
 		function.accept(emitter.doOnComplete(responseObserver::onCompleted)
 				.doOnError(t -> responseObserver
 						.onError(ExceptionConverter.createStatus(t).asException())));

--- a/src/main/java/io/projectriff/invoker/JavaFunctionInvokerController.java
+++ b/src/main/java/io/projectriff/invoker/JavaFunctionInvokerController.java
@@ -33,6 +33,6 @@ public class JavaFunctionInvokerController {
 
 	@PostMapping("/")
 	public String invoke() {
-		return "forward:/" + functions.getFunctionName();
+		return "forward:/" + functions.getName();
 	}
 }

--- a/src/main/java/io/projectriff/invoker/JavaFunctionInvokerServer.java
+++ b/src/main/java/io/projectriff/invoker/JavaFunctionInvokerServer.java
@@ -29,8 +29,10 @@ import com.google.gson.Gson;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.support.MessageBuilder;
 
-import reactor.core.publisher.EmitterProcessor;
+import reactor.core.CoreSubscriber;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Operators;
+import reactor.core.publisher.UnicastProcessor;
 
 /**
  * @author Eric Bottard
@@ -79,8 +81,11 @@ public class JavaFunctionInvokerServer
 	public StreamObserver<io.projectriff.grpc.function.FunctionProtos.Message> call(
 			StreamObserver<io.projectriff.grpc.function.FunctionProtos.Message> responseObserver) {
 
-		EmitterProcessor<Message<?>> emitter = EmitterProcessor.<Message<?>>create();
-		function.apply(emitter).subscribe(
+		UnicastProcessor<Message<?>> emitter = UnicastProcessor.<Message<?>>create();
+		GuardedFlux flux = new GuardedFlux(emitter);
+		Flux<Message<?>> result = function.apply(flux);
+		flux.setSubscribed(true);
+		result.subscribe(
 				message -> responseObserver.onNext(
 						MessageConversionUtils.toGrpc(output.payloadToBytes(message))),
 				t -> responseObserver
@@ -107,6 +112,30 @@ public class JavaFunctionInvokerServer
 			}
 		};
 
+	}
+
+	private final static class GuardedFlux extends Flux<Message<?>> {
+		private boolean subscribed;
+		private final Flux<Message<?>> emitter;
+
+		private GuardedFlux(Flux<Message<?>> emitter) {
+			this.emitter = emitter;
+		}
+
+		@Override
+		public void subscribe(CoreSubscriber<? super Message<?>> actual) {
+			if (subscribed) {
+				emitter.subscribe(actual);
+			}
+			else {
+				Operators.error(actual, new IllegalStateException(
+						"Cannot subscribe inside user function"));
+			}
+		}
+
+		public void setSubscribed(boolean subscribed) {
+			this.subscribed = subscribed;
+		}
 	}
 
 }

--- a/src/main/java/io/projectriff/invoker/JavaSupplierInvokerServer.java
+++ b/src/main/java/io/projectriff/invoker/JavaSupplierInvokerServer.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.projectriff.invoker;
+
+import java.util.function.Supplier;
+
+import io.grpc.stub.StreamObserver;
+import io.projectriff.grpc.function.FunctionProtos.Trigger;
+import io.projectriff.grpc.function.MessageSourceGrpc;
+
+import com.google.gson.Gson;
+
+import org.springframework.messaging.Message;
+
+import reactor.core.publisher.Flux;
+
+/**
+ * @author Eric Bottard
+ * @author Mark Fisher
+ * @author Dave Syer
+ */
+public class JavaSupplierInvokerServer extends MessageSourceGrpc.MessageSourceImplBase {
+
+	private final Supplier<Flux<Message<?>>> supplier;
+	private final MessageConversionUtils converter;
+
+	public JavaSupplierInvokerServer(Supplier<Flux<?>> supplier, Gson mapper,
+			Class<?> outputType, boolean isMessage) {
+		this.converter = new MessageConversionUtils(mapper, outputType);
+		this.supplier = () -> supplier.get()
+				.map(MessageConversionUtils.output(isMessage, supplier));
+	}
+
+	@Override
+	public void call(Trigger request,
+			StreamObserver<io.projectriff.grpc.function.FunctionProtos.Message> responseObserver) {
+
+		supplier.get().subscribe(
+				message -> responseObserver.onNext(
+						MessageConversionUtils.toGrpc(converter.payloadToBytes(message))),
+				t -> responseObserver
+						.onError(ExceptionConverter.createStatus(t).asException()),
+				responseObserver::onCompleted);
+
+	}
+
+}

--- a/src/main/java/io/projectriff/invoker/MessageConversionUtils.java
+++ b/src/main/java/io/projectriff/invoker/MessageConversionUtils.java
@@ -17,13 +17,16 @@ package io.projectriff.invoker;
 
 import java.util.Collection;
 import java.util.Map.Entry;
+import java.util.function.Function;
 
 import io.projectriff.grpc.function.FunctionProtos.Message.Builder;
 import io.projectriff.grpc.function.FunctionProtos.Message.HeaderValue;
 
+import com.google.gson.Gson;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.ProtocolStringList;
 
+import org.springframework.cloud.function.context.message.MessageUtils;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageHeaders;
 import org.springframework.messaging.support.MessageBuilder;
@@ -33,6 +36,15 @@ import org.springframework.messaging.support.MessageBuilder;
  *
  */
 public class MessageConversionUtils {
+
+	private final Gson mapper;
+
+	private Class<?> type;
+
+	public MessageConversionUtils(Gson mapper, Class<?> type) {
+		this.mapper = mapper;
+		this.type = type;
+	}
 
 	public static Message<byte[]> fromGrpc(
 			io.projectriff.grpc.function.FunctionProtos.Message input) {
@@ -81,4 +93,60 @@ public class MessageConversionUtils {
 		return builder.build();
 	}
 
+	public static Function<Object, Message<?>> output(boolean isMessage,
+			Object function) {
+		if (!isMessage) {
+			return payload -> MessageBuilder.withPayload(payload).build();
+		}
+		return message -> MessageUtils.unpack(function, message);
+	}
+
+	public static Function<Message<?>, Object> input(boolean isMessage, Object function) {
+		if (!isMessage) {
+			return message -> message.getPayload();
+		}
+		return message -> MessageUtils.create(function, message.getPayload(),
+				message.getHeaders());
+	}
+
+	public Message<byte[]> payloadToBytes(Message<?> message) {
+		return MessageBuilder.createMessage(toBytes(message.getPayload()),
+				message.getHeaders());
+	}
+
+	public Message<?> payloadFromBytes(Message<byte[]> message) {
+		Message<Object> result = MessageBuilder
+				.createMessage(fromBytes(message.getPayload()), message.getHeaders());
+		return result;
+	}
+
+	private Object fromBytes(byte[] payload) {
+		if (byte[].class.isAssignableFrom(type)) {
+			return payload;
+		}
+		if (CharSequence.class.isAssignableFrom(type)) {
+			return new String(payload);
+		}
+		try {
+			return mapper.fromJson(new String(payload), type);
+		}
+		catch (Exception e) {
+			throw new IllegalStateException("Cannot convert to " + type, e);
+		}
+	}
+
+	private byte[] toBytes(Object payload) {
+		if (payload instanceof byte[]) {
+			return (byte[]) payload;
+		}
+		if (CharSequence.class.isAssignableFrom(type)) {
+			return payload.toString().getBytes();
+		}
+		try {
+			return mapper.toJson(payload).getBytes();
+		}
+		catch (Exception e) {
+			throw new IllegalStateException("Cannot convert from " + type, e);
+		}
+	}
 }

--- a/src/test/java/io/projectriff/functions/Logger.java
+++ b/src/test/java/io/projectriff/functions/Logger.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2016-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.projectriff.functions;
+
+import java.util.function.Consumer;
+
+import reactor.core.publisher.Flux;
+
+/**
+ * @author Dave Syer
+ *
+ */
+public class Logger implements Consumer<Flux<String>> {
+
+	@Override
+	public void accept(Flux<String> input) {
+		input.map(value -> "Hello " + value).subscribe(System.out::println);
+	}
+
+}

--- a/src/test/java/io/projectriff/functions/VoteStreamProcessor.java
+++ b/src/test/java/io/projectriff/functions/VoteStreamProcessor.java
@@ -31,6 +31,8 @@ public class VoteStreamProcessor
 
 	@Override
 	public Flux<Map<String, Object>> apply(Flux<String> words) {
+		// We're going to use it twice so share it to avoid disappointment
+		words = words.share();
 		return Flux.merge(intervals(words), windows(words));
 	}
 

--- a/src/test/java/io/projectriff/functions/Weird.java
+++ b/src/test/java/io/projectriff/functions/Weird.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2016-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.projectriff.functions;
+
+import java.util.function.Function;
+
+import reactor.core.publisher.Flux;
+
+/**
+ * @author Dave Syer
+ *
+ */
+public class Weird implements Function<Flux<String>, Flux<Foo>> {
+
+	@Override
+	public Flux<Foo> apply(Flux<String> input) {
+		input.blockFirst(); // Klaxons!
+		return Flux.just(new Foo("Hello"), new Foo("World"));
+	}
+
+}

--- a/src/test/java/io/projectriff/functions/Words.java
+++ b/src/test/java/io/projectriff/functions/Words.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2016-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.projectriff.functions;
+
+import java.util.function.Supplier;
+
+import reactor.core.publisher.Flux;
+
+/**
+ * @author Dave Syer
+ *
+ */
+public class Words implements Supplier<Flux<String>> {
+
+	@Override
+	public Flux<String> get() {
+		return Flux.just("foo", "bar");
+	}
+
+}

--- a/src/test/java/io/projectriff/invoker/FatJarNextTests.java
+++ b/src/test/java/io/projectriff/invoker/FatJarNextTests.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2016-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.projectriff.invoker;
+
+import java.io.File;
+import java.net.URI;
+
+import org.junit.After;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.RequestEntity;
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.SocketUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Dave Syer
+ *
+ */
+public class FatJarNextTests {
+
+	private TestRestTemplate rest;
+	private int port = SocketUtils.findAvailableTcpPort();
+
+	private File sampleJar;
+
+	private JavaFunctionInvokerApplication runner;
+	private File sampleDir;
+
+	@Before
+	public void init() {
+		runner = new JavaFunctionInvokerApplication();
+		rest = new TestRestTemplate();
+	}
+
+	@After
+	public void close() throws Exception {
+		if (runner != null) {
+			runner.close();
+		}
+	}
+
+	@Before
+	public void check() {
+		sampleDir = new File("target/it/pojo/target/classes");
+		sampleJar = new File(
+				"target/it/next/target/function-sample-next-1.0.0.BUILD-SNAPSHOT.jar");
+		Assume.assumeTrue("Sample jar does not exist: " + sampleJar, sampleJar.exists());
+	}
+
+	@Test
+	public void fatJar() throws Exception {
+		runner.run("--server.port=" + port, "--grpc.port=0",
+				"--function.uri=" + sampleJar.toURI()
+						+ "?handler=uppercase&main=com.example.SampleApplication");
+		ResponseEntity<String> result = rest.exchange(RequestEntity
+				.post(new URI("http://localhost:" + port + "/"))
+				.contentType(MediaType.APPLICATION_JSON).body("{\"value\":\"foo\"}"),
+				String.class);
+		assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+		assertThat(result.getBody()).isEqualTo("[{\"value\":\"FOO\"}]");
+	}
+
+	@Test
+	public void fatJarAndDirectory() throws Exception {
+		runner.run("--server.port=" + port, "--grpc.port=0",
+				"--function.uri=" + sampleDir.toURI() + "," + sampleJar.toURI()
+						+ "?handler=uppercase&main=com.example.SampleApplication");
+		ResponseEntity<String> result = rest.exchange(RequestEntity
+				.post(new URI("http://localhost:" + port + "/"))
+				.contentType(MediaType.APPLICATION_JSON).body("{\"value\":\"foo\"}"),
+				String.class);
+		assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+		assertThat(result.getBody()).isEqualTo("[{\"value\":\"FOO\"}]");
+	}
+}

--- a/src/test/java/io/projectriff/invoker/GrpcIsolatedTests.java
+++ b/src/test/java/io/projectriff/invoker/GrpcIsolatedTests.java
@@ -88,6 +88,16 @@ public class GrpcIsolatedTests {
 	}
 
 	@Test
+	// @Ignore("Function that blocks really gums things up")
+	public void weirdFunction() throws Exception {
+		runner.run("--server.port=0", "--grpc.port=" + port,
+				"--function.uri=file:target/test-classes"
+						+ "?handler=io.projectriff.functions.Weird");
+		List<String> result = client.send("start");
+		assertThat(result).isEmpty();
+	}
+
+	@Test
 	public void fluxJson() throws Exception {
 		runner.run("--server.port=0", "--grpc.port=" + port,
 				"--function.uri=file:target/test-classes"

--- a/src/test/java/io/projectriff/invoker/GrpcSinkTests.java
+++ b/src/test/java/io/projectriff/invoker/GrpcSinkTests.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.projectriff.invoker;
+
+import java.util.List;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.util.SocketUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Dave Syer
+ */
+public class GrpcSinkTests {
+
+	private int port = SocketUtils.findAvailableTcpPort();
+
+	@Rule
+	public ExpectedException expected = ExpectedException.none();
+	private JavaFunctionInvokerApplication runner;
+
+	private GrpcTestClient client;
+
+	@Before
+	public void init() {
+		runner = new JavaFunctionInvokerApplication();
+		client = new GrpcTestClient("localhost", port);
+	}
+
+	@After
+	public void close() throws Exception {
+		if (runner != null) {
+			runner.close();
+		}
+	}
+
+	@Test
+	public void fluxConsumer() throws Exception {
+		runner.run("--server.port=0", "--grpc.port=" + port,
+				"--function.uri=file:target/test-classes"
+						+ "?handler=io.projectriff.functions.Logger");
+		List<String> result = client.send("foo");
+		assertThat(result).isEmpty();
+		ApplicationRunner runner = (ApplicationRunner) ReflectionTestUtils
+				.getField(this.runner, "runner");
+		assertThat(runner.containsBean("io.projectriff.functions.Logger")).isFalse();
+	}
+}

--- a/src/test/java/io/projectriff/invoker/GrpcSourceTests.java
+++ b/src/test/java/io/projectriff/invoker/GrpcSourceTests.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.projectriff.invoker;
+
+import java.util.List;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.util.SocketUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Dave Syer
+ */
+public class GrpcSourceTests {
+
+	private int port = SocketUtils.findAvailableTcpPort();
+
+	@Rule
+	public ExpectedException expected = ExpectedException.none();
+	private JavaFunctionInvokerApplication runner;
+
+	private SourceTestClient client;
+
+	@Before
+	public void init() {
+		runner = new JavaFunctionInvokerApplication();
+		client = new SourceTestClient("localhost", port);
+	}
+
+	@After
+	public void close() throws Exception {
+		if (runner != null) {
+			runner.close();
+		}
+	}
+
+	@Test
+	public void fluxSupplier() throws Exception {
+		runner.run("--server.port=0", "--grpc.port=" + port,
+				"--function.uri=file:target/test-classes"
+						+ "?handler=io.projectriff.functions.Words");
+		List<String> result = client.send();
+		assertThat(result).contains("foo");
+		ApplicationRunner runner = (ApplicationRunner) ReflectionTestUtils
+				.getField(this.runner, "runner");
+		assertThat(runner.containsBean("io.projectriff.functions.Words")).isFalse();
+	}
+}

--- a/src/test/java/io/projectriff/invoker/SourceTestClient.java
+++ b/src/test/java/io/projectriff/invoker/SourceTestClient.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2016-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.projectriff.invoker;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.stub.StreamObserver;
+import io.projectriff.grpc.function.FunctionProtos.Message;
+import io.projectriff.grpc.function.FunctionProtos.Trigger;
+import io.projectriff.grpc.function.MessageSourceGrpc;
+import io.projectriff.grpc.function.MessageSourceGrpc.MessageSourceStub;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+/**
+ * @author Dave Syer
+ *
+ */
+public class SourceTestClient {
+	private final Log logger = LogFactory.getLog(SourceTestClient.class);
+
+	private final ManagedChannel channel;
+	private final MessageSourceStub asyncStub;
+
+	public SourceTestClient(String host, int port) {
+		this(ManagedChannelBuilder.forAddress(host, port).usePlaintext(true));
+	}
+
+	public SourceTestClient(ManagedChannelBuilder<?> channelBuilder) {
+		channel = channelBuilder.build();
+		asyncStub = MessageSourceGrpc.newStub(channel);
+	}
+
+	public void shutdown() throws InterruptedException {
+		channel.shutdown().awaitTermination(5, TimeUnit.SECONDS);
+	}
+
+	public List<String> send() throws Exception {
+		return send(message -> new String(message.getPayload().toByteArray()));
+	}
+
+	public <T> List<T> send(Function<Message, T> xform) throws Exception {
+		CountDownLatch latch = new CountDownLatch(1);
+		List<T> value = new ArrayList<>();
+		Trigger trigger = Trigger.getDefaultInstance();
+		asyncStub.call(trigger, new StreamObserver<Message>() {
+
+			@Override
+			public void onNext(Message message) {
+				logger.info("Message: " + message);
+				value.add(xform.apply(message));
+			}
+
+			@Override
+			public void onError(Throwable t) {
+				logger.error("Error", t);
+				latch.countDown();
+			}
+
+			@Override
+			public void onCompleted() {
+				logger.info("Finished");
+				latch.countDown();
+			}
+		});
+		latch.await(10, TimeUnit.SECONDS);
+		return value;
+	}
+}


### PR DESCRIPTION
With a bit of reflection to call the right method we can start Spring Boot
1.5 and Spring Boot 2.0 functions from the same invoker app.

Fixes gh-49

(Applied on top of gh-47)