### PR TITLE
Make errors in grpc input visible

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<java.version>1.8</java.version>
 		<spring-cloud.version>Edgware.SR2</spring-cloud.version>
-		<spring-cloud-function.version>1.0.0.M5</spring-cloud-function.version>
+		<spring-cloud-function.version>1.0.0.BUILD-SNAPSHOT</spring-cloud-function.version>
 		<spring-cloud-deployer.version>1.2.0.RELEASE</spring-cloud-deployer.version>
 		<grpc.version>1.8.0</grpc.version>
 		<reactor.version>3.2.0.M1</reactor.version>

--- a/src/main/java/io/projectriff/invoker/JavaFunctionInvokerServer.java
+++ b/src/main/java/io/projectriff/invoker/JavaFunctionInvokerServer.java
@@ -73,7 +73,7 @@ public class JavaFunctionInvokerServer
 	private Message<?> retrieveHeaders(AtomicReference<Map<String, Object>> headers,
 			Message<?> message) {
 		Map<String, Object> map = headers.getAndSet(Collections.emptyMap());
-		if (map.isEmpty()) {
+		if (map == null || map.isEmpty()) {
 			return message;
 		}
 		return MessageBuilder.fromMessage(message).copyHeadersIfAbsent(map).build();
@@ -113,9 +113,10 @@ public class JavaFunctionInvokerServer
 		result.subscribe(
 				message -> responseObserver
 						.onNext(MessageConversionUtils.toGrpc(payloadToBytes(message))),
-				t -> responseObserver
-						.onError(ExceptionConverter.createStatus(t).asException()),
-				responseObserver::onCompleted);
+				t -> {
+					throw new IllegalStateException(
+							ExceptionConverter.createStatus(t).asException());
+				}, responseObserver::onCompleted);
 
 		return new StreamObserver<io.projectriff.grpc.function.FunctionProtos.Message>() {
 

--- a/src/test/java/io/projectriff/invoker/FunctionConfigurationTests.java
+++ b/src/test/java/io/projectriff/invoker/FunctionConfigurationTests.java
@@ -18,7 +18,6 @@ package io.projectriff.invoker;
 
 import java.util.function.Consumer;
 import java.util.function.Function;
-import java.util.function.Supplier;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -36,6 +35,8 @@ import org.springframework.test.context.junit4.SpringRunner;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
+
+import reactor.core.publisher.Flux;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = { FunctionConfiguration.class, FunctionProperties.class,
@@ -68,8 +69,9 @@ public abstract class FunctionConfigurationTests {
 
 		@Test
 		public void testSupplier() {
-			Supplier<Integer> function = catalog.lookup(Supplier.class, "function0");
-			assertThat(function.get(), is(1));
+			Function<Flux<?>, Flux<Integer>> function = catalog.lookup(Function.class,
+					"function0");
+			assertThat(function.apply(Flux.empty()).blockFirst(), is(1));
 		}
 
 		@Test

--- a/src/test/java/io/projectriff/invoker/GrpcIsolatedTests.java
+++ b/src/test/java/io/projectriff/invoker/GrpcIsolatedTests.java
@@ -95,6 +95,16 @@ public class GrpcIsolatedTests {
 						+ "?handler=io.projectriff.functions.Weird");
 		List<String> result = client.send("start");
 		assertThat(result).isEmpty();
+
+	}
+
+	@Test
+	public void supplier() throws Exception {
+		runner.run("--server.port=0", "--grpc.port=" + port,
+				"--function.uri=file:target/test-classes"
+						+ "?handler=io.projectriff.functions.NumberEmitter");
+		List<String> result = client.send();
+		assertThat(result).contains("1");
 	}
 
 	@Test
@@ -169,7 +179,7 @@ public class GrpcIsolatedTests {
 		assertThat(result).contains("10");
 	}
 
-	@Test(expected = IllegalStateException.class)
+	@Test(expected = Exception.class)
 	public void nonExistentFunctionWithMain() throws Exception {
 		runner.run("--server.port=0", "--grpc.port=" + port,
 				"--function.uri=app:classpath?" + "handler=notThere&"


### PR DESCRIPTION
It is better to throw the exception and let reactor log it than
to try and relay it to the caller. As a side effect, since to test
it we needed an empty input stream, we now have support for
event sources (just write a Supplier and it will be adapted to
a Function that discards its input).