### PR TITLE
Add generated riff cli docs to README

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ cache:
 matrix:
   include:
   - stage: test
+    before_install: go get github.com/projectriff/riff
+    script: make test verify-docs
   - stage: publish
     sudo: required
     services:

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,20 @@
+.PHONY: test docs verify-docs
+COMPONENT = java-function-invoker
+NAME = java
+
+test:
+	./mvnw test -B
+
+docs:
+	RIFF_INVOKER_PATHS=$(NAME)-invoker.yaml riff docs -d docs -c "init $(NAME)"
+	RIFF_INVOKER_PATHS=$(NAME)-invoker.yaml riff docs -d docs -c "create $(NAME)"
+	$(call embed_readme,init,$(NAME))
+	$(call embed_readme,create,$(NAME))
+
+define embed_readme
+    $(shell cat README.md | perl -e 'open(my $$fh, "docs/riff_$(1)_$(2).md") or die "cannot open doc"; my $$doc = join("", <$$fh>) =~ s/^#/##/rmg; print join("", <STDIN>) =~ s/(?<=<!-- riff-$(1) -->\n).*(?=\n<!-- \/riff-$(1) -->)/\n$$doc/sr' > README.$(1).md; mv README.$(1).md README.md)
+endef
+
+verify-docs: docs
+	git diff --exit-code -- docs
+	git diff --exit-code -- README.md

--- a/README.md
+++ b/README.md
@@ -1,15 +1,10 @@
-# Java Function Invoker image:https://travis-ci.org/projectriff/java-function-invoker.svg?branch=master[Java Invoker, link=https://travis-ci.org/projectriff/java-function-invoker]
+
+# Java Function Invoker [![Build Status](https://travis-ci.org/projectriff/java-function-invoker.svg?branch=master)](https://travis-ci.org/projectriff/java-function-invoker)
 
 ## Install as a riff invoker
 
 ```bash
 riff invokers apply -f java-invoker.yaml
-```
-
-or
-
-```bash
-kubectl apply -f java-invoker.yaml
 ```
 
 ## Usage
@@ -116,3 +111,114 @@ Then
 $ curl -v localhost:8080 -H "Content-Type: text/plain" -d 5
 10
 ```
+
+## riff Commands
+
+- [riff init java](#riff-init-java)
+- [riff create java](#riff-create-java)
+
+<!-- riff-init -->
+
+### riff init java
+
+Initialize a java function
+
+#### Synopsis
+
+Generate the function based on the function source code specified as the filename, using the artifact (jar file),
+the function handler (classname or bean name), the name and version specified for the function image repository and tag.
+
+For example, from a maven project directory named 'greeter', type:
+
+    riff init java -i greetings -a target/greeter-1.0.0.jar --handler=functions.Greeter
+
+to generate the resource definitions using sensible defaults.
+
+
+```
+riff init java [flags]
+```
+
+#### Options
+
+```
+      --handler string           the fully qualified class name or bean name of the function handler (default "functions.{{ .TitleCase .FunctionName }}")
+  -h, --help                     help for java
+      --invoker-version string   the version of invoker to use when building containers (default "0.0.6-snapshot")
+```
+
+#### Options inherited from parent commands
+
+```
+  -a, --artifact string      path to the function artifact, source code or jar file
+      --config string        config file (default is $HOME/.riff.yaml)
+      --dry-run              print generated function artifacts content to stdout only
+  -f, --filepath string      path or directory used for the function resources (defaults to the current directory)
+      --force                overwrite existing functions artifacts
+  -i, --input string         the name of the input topic (defaults to function name)
+  -n, --name string          the name of the function (defaults to the name of the current directory)
+  -o, --output string        the name of the output topic (optional)
+  -u, --useraccount string   the Docker user account to be used for the image repository (default "current OS user")
+  -v, --version string       the version of the function image (default "0.0.1")
+```
+
+#### SEE ALSO
+
+* [riff init](https://github.com/projectriff/riff/blob/master/riff-cli/docs/riff_init.md)	 - Initialize a function
+
+
+<!-- /riff-init -->
+
+<!-- riff-create -->
+
+### riff create java
+
+Create a java function
+
+#### Synopsis
+
+Create the function based on the function source code specified as the filename, using the artifact (jar file),
+the function handler (classname or bean name), the name and version specified for the function image repository and tag.
+
+For example, from a maven project directory named 'greeter', type:
+
+    riff create java -i greetings -a target/greeter-1.0.0.jar --handler=functions.Greeter
+
+to create the resource definitions, and apply the resources, using sensible defaults.
+
+
+```
+riff create java [flags]
+```
+
+#### Options
+
+```
+      --handler string           the fully qualified class name or bean name of the function handler (default "functions.{{ .TitleCase .FunctionName }}")
+  -h, --help                     help for java
+      --invoker-version string   the version of invoker to use when building containers (default "0.0.6-snapshot")
+      --namespace string         the namespace used for the deployed resources (defaults to kubectl's default)
+      --push                     push the image to Docker registry
+```
+
+#### Options inherited from parent commands
+
+```
+  -a, --artifact string      path to the function artifact, source code or jar file
+      --config string        config file (default is $HOME/.riff.yaml)
+      --dry-run              print generated function artifacts content to stdout only
+  -f, --filepath string      path or directory used for the function resources (defaults to the current directory)
+      --force                overwrite existing functions artifacts
+  -i, --input string         the name of the input topic (defaults to function name)
+  -n, --name string          the name of the function (defaults to the name of the current directory)
+  -o, --output string        the name of the output topic (optional)
+  -u, --useraccount string   the Docker user account to be used for the image repository (default "current OS user")
+  -v, --version string       the version of the function image (default "0.0.1")
+```
+
+#### SEE ALSO
+
+* [riff create](https://github.com/projectriff/riff/blob/master/riff-cli/docs/riff_create.md)	 - Create a function (equivalent to init, build, apply)
+
+
+<!-- /riff-create -->

--- a/docs/riff_create_java.md
+++ b/docs/riff_create_java.md
@@ -1,0 +1,49 @@
+## riff create java
+
+Create a java function
+
+### Synopsis
+
+Create the function based on the function source code specified as the filename, using the artifact (jar file),
+the function handler (classname or bean name), the name and version specified for the function image repository and tag.
+
+For example, from a maven project directory named 'greeter', type:
+
+    riff create java -i greetings -a target/greeter-1.0.0.jar --handler=functions.Greeter
+
+to create the resource definitions, and apply the resources, using sensible defaults.
+
+
+```
+riff create java [flags]
+```
+
+### Options
+
+```
+      --handler string           the fully qualified class name or bean name of the function handler (default "functions.{{ .TitleCase .FunctionName }}")
+  -h, --help                     help for java
+      --invoker-version string   the version of invoker to use when building containers (default "0.0.6-snapshot")
+      --namespace string         the namespace used for the deployed resources (defaults to kubectl's default)
+      --push                     push the image to Docker registry
+```
+
+### Options inherited from parent commands
+
+```
+  -a, --artifact string      path to the function artifact, source code or jar file
+      --config string        config file (default is $HOME/.riff.yaml)
+      --dry-run              print generated function artifacts content to stdout only
+  -f, --filepath string      path or directory used for the function resources (defaults to the current directory)
+      --force                overwrite existing functions artifacts
+  -i, --input string         the name of the input topic (defaults to function name)
+  -n, --name string          the name of the function (defaults to the name of the current directory)
+  -o, --output string        the name of the output topic (optional)
+  -u, --useraccount string   the Docker user account to be used for the image repository (default "current OS user")
+  -v, --version string       the version of the function image (default "0.0.1")
+```
+
+### SEE ALSO
+
+* [riff create](https://github.com/projectriff/riff/blob/master/riff-cli/docs/riff_create.md)	 - Create a function (equivalent to init, build, apply)
+

--- a/docs/riff_init_java.md
+++ b/docs/riff_init_java.md
@@ -1,0 +1,47 @@
+## riff init java
+
+Initialize a java function
+
+### Synopsis
+
+Generate the function based on the function source code specified as the filename, using the artifact (jar file),
+the function handler (classname or bean name), the name and version specified for the function image repository and tag.
+
+For example, from a maven project directory named 'greeter', type:
+
+    riff init java -i greetings -a target/greeter-1.0.0.jar --handler=functions.Greeter
+
+to generate the resource definitions using sensible defaults.
+
+
+```
+riff init java [flags]
+```
+
+### Options
+
+```
+      --handler string           the fully qualified class name or bean name of the function handler (default "functions.{{ .TitleCase .FunctionName }}")
+  -h, --help                     help for java
+      --invoker-version string   the version of invoker to use when building containers (default "0.0.6-snapshot")
+```
+
+### Options inherited from parent commands
+
+```
+  -a, --artifact string      path to the function artifact, source code or jar file
+      --config string        config file (default is $HOME/.riff.yaml)
+      --dry-run              print generated function artifacts content to stdout only
+  -f, --filepath string      path or directory used for the function resources (defaults to the current directory)
+      --force                overwrite existing functions artifacts
+  -i, --input string         the name of the input topic (defaults to function name)
+  -n, --name string          the name of the function (defaults to the name of the current directory)
+  -o, --output string        the name of the output topic (optional)
+  -u, --useraccount string   the Docker user account to be used for the image repository (default "current OS user")
+  -v, --version string       the version of the function image (default "0.0.1")
+```
+
+### SEE ALSO
+
+* [riff init](https://github.com/projectriff/riff/blob/master/riff-cli/docs/riff_init.md)	 - Initialize a function
+

--- a/java-invoker.yaml
+++ b/java-invoker.yaml
@@ -28,6 +28,6 @@ spec:
     
     For example, from a maven project directory named 'greeter', type:
     
-        riff {{.Command}} java -i greetings -a target/greeter-1.0.0.jar --handler=functions.Greeter
+        riff {{.Command}} -i greetings -a target/greeter-1.0.0.jar --handler=functions.Greeter
     
     to {{.Result}}.


### PR DESCRIPTION
- converted readme to markdown
- generate docs for `riff init java` and `riff create java` in
  docs directory
- embed command docs into the README
- fail CI if the generated docs drift from what's committed

Refs: projectriff/riff#454