### PR TITLE
Add a flag so that app can close when stream ends

### DIFF
--- a/src/main/java/io/projectriff/invoker/ApplicationRunner.java
+++ b/src/main/java/io/projectriff/invoker/ApplicationRunner.java
@@ -152,6 +152,15 @@ public class ApplicationRunner {
 		return parsed.getValue(context);
 	}
 
+	public boolean isRunning() {
+		if (this.app == null) {
+			return false;
+		}
+		Expression parsed = new SpelExpressionParser()
+				.parseExpression("context.isRunning()");
+		return parsed.getValue(this.app, Boolean.class);
+	}
+
 	@PreDestroy
 	public void close() {
 		closeContext();

--- a/src/test/java/io/projectriff/functions/Logger.java
+++ b/src/test/java/io/projectriff/functions/Logger.java
@@ -27,7 +27,7 @@ public class Logger implements Consumer<Flux<String>> {
 
 	@Override
 	public void accept(Flux<String> input) {
-		input.map(value -> "Hello " + value).subscribe(System.out::println);
+		input.map(value -> "Hello " + value).doOnNext(System.out::println);
 	}
 
 }

--- a/src/test/java/io/projectriff/invoker/GrpcSinkTests.java
+++ b/src/test/java/io/projectriff/invoker/GrpcSinkTests.java
@@ -65,5 +65,18 @@ public class GrpcSinkTests {
 		ApplicationRunner runner = (ApplicationRunner) ReflectionTestUtils
 				.getField(this.runner, "runner");
 		assertThat(runner.containsBean("io.projectriff.functions.Logger")).isFalse();
+		assertThat(runner.isRunning()).isTrue();
+	}
+
+	@Test
+	public void fluxConsumerCloses() throws Exception {
+		runner.run("--server.port=0", "--grpc.port=" + port, "--grpc.exitOnComplete=true",
+				"--function.uri=file:target/test-classes"
+						+ "?handler=io.projectriff.functions.Logger");
+		List<String> result = client.send("foo");
+		assertThat(result).isEmpty();
+		ApplicationRunner runner = (ApplicationRunner) ReflectionTestUtils
+				.getField(this.runner, "runner");
+		assertThat(runner.isRunning()).isFalse();
 	}
 }

--- a/src/test/java/io/projectriff/invoker/GrpcSourceTests.java
+++ b/src/test/java/io/projectriff/invoker/GrpcSourceTests.java
@@ -65,5 +65,18 @@ public class GrpcSourceTests {
 		ApplicationRunner runner = (ApplicationRunner) ReflectionTestUtils
 				.getField(this.runner, "runner");
 		assertThat(runner.containsBean("io.projectriff.functions.Words")).isFalse();
+		assertThat(runner.isRunning()).isTrue();
+	}
+
+	@Test
+	public void fluxSupplierCloses() throws Exception {
+		runner.run("--server.port=0", "--grpc.port=" + port, "--grpc.exitOnComplete=true",
+				"--function.uri=file:target/test-classes"
+						+ "?handler=io.projectriff.functions.Words");
+		List<String> result = client.send();
+		assertThat(result).contains("foo");
+		ApplicationRunner runner = (ApplicationRunner) ReflectionTestUtils
+				.getField(this.runner, "runner");
+		assertThat(runner.isRunning()).isFalse();
 	}
 }


### PR DESCRIPTION
If user sets grpc.exitOnComplete=true then the app will close
down after the end of the output flux (which is the same as the
end of the input flux for a Consumer).

See https://github.com/projectriff/riff/pull/544 for a change
in the sidecar that supports this, and makes it possible to
declare a k8s Job with a sidecar and a function invoker.

N.B. this change can be merged independent of the other one
(the default behaviour hasn't changed).