### PR TITLE
Existing gRPC exceptions can be passed through unchanged

### DIFF
--- a/src/main/java/io/projectriff/invoker/ExceptionConverter.java
+++ b/src/main/java/io/projectriff/invoker/ExceptionConverter.java
@@ -6,12 +6,20 @@ import java.util.concurrent.CancellationException;
 import java.util.concurrent.TimeoutException;
 
 import io.grpc.Status;
+import io.grpc.StatusException;
+import io.grpc.StatusRuntimeException;
 
 /**
  * Utility class for converting exceptions to gRPC status values.
  */
 final class ExceptionConverter {
 	static Status createStatus(Throwable t) {
+		if (t instanceof StatusRuntimeException) {
+			return ((StatusRuntimeException) t).getStatus();
+		}
+		if (t instanceof StatusException) {
+			return ((StatusException) t).getStatus();
+		}
 		return Status.fromCode(determineCode(t)).withDescription(t.getMessage())
 				.withCause(t);
 	}

--- a/src/main/java/io/projectriff/invoker/JavaFunctionInvokerServer.java
+++ b/src/main/java/io/projectriff/invoker/JavaFunctionInvokerServer.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 
+import io.grpc.StatusRuntimeException;
 import io.grpc.stub.StreamObserver;
 import io.projectriff.grpc.function.MessageFunctionGrpc;
 
@@ -116,9 +117,16 @@ public class JavaFunctionInvokerServer
 				message -> responseObserver
 						.onNext(MessageConversionUtils.toGrpc(payloadToBytes(message))),
 				t -> {
+					if (t instanceof StatusRuntimeException) {
+						// Not particularly exceptional.
+						logger.info("RPC ending: " + t.getClass().getName() + " ("
+								+ t.getMessage() + ")");
+					}
+					else {
+						t = ExceptionConverter.createStatus(t).asRuntimeException();
+						logger.error("RPC ending", t);
+					}
 					responseObserver.onError(t);
-					throw new IllegalStateException(
-							ExceptionConverter.createStatus(t).asException());
 				}, () -> {
 					// Make sure the emitter is disposed (should work even if it already
 					// was since it's idempotent)

--- a/src/test/java/io/projectriff/invoker/ExceptionConverterTests.java
+++ b/src/test/java/io/projectriff/invoker/ExceptionConverterTests.java
@@ -6,6 +6,8 @@ import java.util.concurrent.CancellationException;
 import java.util.concurrent.TimeoutException;
 
 import io.grpc.Status;
+import io.grpc.StatusException;
+import io.grpc.StatusRuntimeException;
 
 import org.junit.Test;
 
@@ -14,6 +16,17 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class ExceptionConverterTests {
 
 	private static final String TEST_MESSAGE = "test message";
+
+	@Test
+	public void statusRuntime() {
+		checkStatus(new StatusRuntimeException(Status.CANCELLED), Status.Code.CANCELLED,
+				null);
+	}
+
+	@Test
+	public void status() {
+		checkStatus(new StatusException(Status.CANCELLED), Status.Code.CANCELLED, null);
+	}
 
 	@Test
 	public void cancelled() {
@@ -107,10 +120,17 @@ public class ExceptionConverterTests {
 	}
 
 	private void checkStatus(Throwable cause, Status.Code expectedCode) {
+		checkStatus(cause, expectedCode, TEST_MESSAGE);
+	}
+
+	private void checkStatus(Throwable cause, Status.Code expectedCode,
+			String description) {
 		Status s = ExceptionConverter.createStatus(cause);
 		assertThat(s.getCode()).isEqualTo(expectedCode);
-		assertThat(s.getDescription()).isEqualTo(TEST_MESSAGE);
-		assertThat(s.getCause()).isEqualTo(cause);
+		assertThat(s.getDescription()).isEqualTo(description);
+		if (s.getCause() != null) {
+			assertThat(s.getCause()).isEqualTo(cause);
+		}
 	}
 
 	@SuppressWarnings("serial")


### PR DESCRIPTION
They aren't particularly exceptional and there is no need to wrap
them again.