### PR TITLE
DO NOT MERGE: Set initialDelayMs to 5000

### DIFF
--- a/java-invoker.yaml
+++ b/java-invoker.yaml
@@ -14,6 +14,7 @@ spec:
   functionTemplate:
     spec:
       protocol: grpc
+      initialDelayMs: 5000
   files:
   - path: Dockerfile
     template: |


### PR DESCRIPTION
This depends on https://github.com/projectriff/riff/pull/576 . This forces the sidecar to wait 5 sec by default for the function container to start before starting the dispatcher