### PR TITLE
Bump spring-cloud-function version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<java.version>1.8</java.version>
-		<spring-cloud-function.version>2.0.0.M2</spring-cloud-function.version>
+		<spring-cloud-function.version>2.0.0.BUILD-SNAPSHOT</spring-cloud-function.version>
 		<dockerfile-maven.version>1.4.3</dockerfile-maven.version>
 		<docker.org>projectriff</docker.org>
 		<docker.tag>0.1.2-snapshot</docker.tag>

--- a/src/it/next/src/main/resources/application.properties
+++ b/src/it/next/src/main/resources/application.properties
@@ -1,1 +1,1 @@
-management.security.enabled: false
+#management.security.enabled: false

--- a/src/it/pojo/pom.xml
+++ b/src/it/pojo/pom.xml
@@ -64,6 +64,28 @@
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
 			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-dependency-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>unpack</id>
+						<phase>package</phase>
+						<goals>
+							<goal>unpack</goal>
+						</goals>
+						<configuration>
+							<artifactItems>
+								<artifactItem>
+									<groupId>${project.groupId}</groupId>
+									<artifactId>${project.artifactId}</artifactId>
+									<version>${project.version}</version>
+								</artifactItem>
+							</artifactItems>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
 


### PR DESCRIPTION
Snapshots of spring-cloud-function should support exploded
Spring Boot archives (like in a buildpack). If it works on
master / latest / snapshots we can do a full release.

Fixes #97