### PR TITLE
Enhance URL parsing and fix doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,23 +230,23 @@ Examples:
 * A jar file
 
 ```
-file:target/app.jar&handler=functions.Greeter
+file:target/app.jar?handler=functions.Greeter
 ```
 
 * A Spring app (with `spring-cloud-function-context`) and function specified by bean class
 
 ```
-file:target/app.jar&handler=functions.Greeter&main=functions.Application
+file:target/app.jar?handler=functions.Greeter&main=functions.Application
 ```
 
 * A Spring app and function specified by bean name
 
 ```
-file:target/app.jar&handler=greeter&main=functions.Application
+file:target/app.jar?handler=greeter&main=functions.Application
 ```
 
 * A Spring app split between 2 jar files
 
 ```
-file:target/app.jar,file:target/lib.jar&handler=greeter&main=functions.Application
+file:target/app.jar,file:target/lib.jar?handler=greeter&main=functions.Application
 ```


### PR DESCRIPTION
This fixes some minor issues, replacing the `function.uri` regex with `java.net.URL` parsing. 

* Accepts  main without handler `file:/target/my.jar?main=functions.App` technically not required for `@SpringBootApplication` but does not result in error
* Accepts `handler` and `main` parameters in any order
* Protocol defaults to `file:` if not provided. 
* Correct README samples



