### PR TITLE
Upgrade Netty to 4.1.39.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,20 @@
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>
+			<!-- temporary until new release of
+
+			spring-boot-starter-webflux
+				|_ spring-boot-starter-reactor-netty
+					|_ reactor-netty
+						|_ netty*
+			-->
+			<dependency>
+				<groupId>io.netty</groupId>
+				<artifactId>netty-bom</artifactId>
+				<version>4.1.39.Final</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
 		</dependencies>
 	</dependencyManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.1.2.RELEASE</version>
+		<version>2.1.7.RELEASE</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<java.version>11</java.version>
-		<spring-cloud-function.version>2.0.1.RELEASE</spring-cloud-function.version>
+		<spring-cloud-function.version>2.0.2.RELEASE</spring-cloud-function.version>
 		<skip.invoke>true</skip.invoke>
 	</properties>
 


### PR DESCRIPTION
[This](https://netty.io/news/2019/08/13/4-1-39-Final.html) fixes a number of [HTTP/2 vulnerabilities](https://www.kb.cert.org/vuls/id/605641/).

See https://github.com/projectriff/riff/issues/1354 for more context.