### PR TITLE
Fix function type discovery

### DIFF
--- a/src/main/java/io/projectriff/invoker/main/EntryPoint.java
+++ b/src/main/java/io/projectriff/invoker/main/EntryPoint.java
@@ -9,7 +9,6 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.function.context.FunctionCatalog;
 import org.springframework.cloud.function.context.FunctionProperties;
-import org.springframework.cloud.function.context.catalog.FunctionInspector;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.context.annotation.Bean;
 
@@ -40,10 +39,9 @@ public class EntryPoint {
     }
 
     @Bean
-    public GrpcServerAdapter adapter(FunctionCatalog functionCatalog, FunctionInspector functionInspector, FunctionProperties functionProperties) {
+    public GrpcServerAdapter adapter(FunctionCatalog functionCatalog, FunctionProperties functionProperties) {
         return new GrpcServerAdapter(
                 functionCatalog,
-                functionInspector,
                 functionProperties.getDefinition()
         );
     }

--- a/src/main/java/io/projectriff/invoker/server/GrpcServerAdapter.java
+++ b/src/main/java/io/projectriff/invoker/server/GrpcServerAdapter.java
@@ -7,7 +7,6 @@ import io.projectriff.invoker.rpc.OutputFrame;
 import io.projectriff.invoker.rpc.OutputSignal;
 import io.projectriff.invoker.rpc.ReactorRiffGrpc;
 import org.springframework.cloud.function.context.FunctionCatalog;
-import org.springframework.cloud.function.context.catalog.FunctionInspector;
 import org.springframework.cloud.function.context.catalog.FunctionTypeUtils;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageHeaders;
@@ -28,18 +27,16 @@ import java.util.function.Function;
  * Reactive gRPC adapter for riff.
  *
  * @author Eric Bottard
+ * @author Oleg Zhurakousky
  */
 public class GrpcServerAdapter extends ReactorRiffGrpc.RiffImplBase {
 
     private final FunctionCatalog functionCatalog;
 
-    private final FunctionInspector functionInspector;
-
     private final String functionName;
 
-    public GrpcServerAdapter(FunctionCatalog functionCatalog, FunctionInspector functionInspector, String functionName) {
+    public GrpcServerAdapter(FunctionCatalog functionCatalog, String functionName) {
         this.functionCatalog = functionCatalog;
-        this.functionInspector = functionInspector;
         this.functionName = functionName;
     }
 
@@ -98,10 +95,8 @@ public class GrpcServerAdapter extends ReactorRiffGrpc.RiffImplBase {
     }
 
     private Function<Flux<Tuple2<Integer, Message<byte[]>>>, Flux<Tuple2<Integer, Message<byte[]>>>> invoker(Function<Object, Object> springCloudFunction) {
-        //Type functionType = FunctionTypeUtils.discoverFunctionTypeFromClass(springCloudFunction.getClass());
-        // TODO: functionInspector is going away but is currently the correct way to discover arity
-        // SCF@master is currently broken for some cases otherwise
-        Type functionType = this.functionInspector.getRegistration(springCloudFunction).getType().getType();
+        Type functionType = FunctionTypeUtils.discoverFunctionTypeFromFunctionalObject(springCloudFunction);
+
         int arity = FunctionTypeUtils.getInputCount(functionType);
 
         Tuple2<Integer, Message<byte[]>>[] startTuples = new Tuple2[arity];


### PR DESCRIPTION
- Fixed function type discovery in GrpcServerAdapter to avoid using FunctionInspector and instead rely on new FunctionTypeUtils.discoverFunctionTypeFromFunctionalObject() method
- Removed dependencies on FunctionInspector